### PR TITLE
fix: The eventfd_signal function in TrueNAS kernel 6.6 does not require the patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,12 @@ This project makes it simple to use GPU-P on Linux with the latest kernel VM. 
 
 ### Available on
 
-- Ubuntu Server 24.04 LTS (Tensorflow is working)
-   - 6.8.0-1007-azure
-   - 6.8.0-31-generic
+- Ubuntu | Ubuntu Server
+   - 24.04 LTS @ 6.8.0
+   - 22.04 LTS @ 5.15.0 ~ 6.5.0
 
-- Ubuntu 22.04 LTS (just installed, not tested)
-   - 6.5.0-18-generic
-   - 6.2.0-39-generic
-   - 6.1.0-1036-oem
-   - 6.0.0-1016-oem
-   - 5.19.0-50-generic
-   - 5.17.0-1035-oem
-   - 5.15.0-94-generic
+-  TrueNAS SCALE
+   - 23.10.2 @ 6.6.44-production+truenas
 
 ### Requirements
 

--- a/install.sh
+++ b/install.sh
@@ -28,7 +28,7 @@ install_dependencies() {
 
 update_git() {
     SYSTEM_KERNEL_VERSION="`echo ${TARGET_KERNEL_VERSION} | grep -Po ^[0-9]+\.[0-9]+`"
-    if [ "${SYSTEM_KERNEL_VERSION:0:1}" -ge "6" ] & [ "${SYSTEM_KERNEL_VERSION:2}" -ge "6" ]; then
+    if [ "${SYSTEM_KERNEL_VERSION:0:1}" -ge "6" ] && [ "${SYSTEM_KERNEL_VERSION:2}" -ge "6" ]; then
         TARGET_BRANCH="linux-msft-wsl-6.6.y";
     else
         TARGET_BRANCH="linux-msft-wsl-5.15.y";
@@ -169,7 +169,7 @@ clean() {
         exit 0
     elif [ "$1" == "all" ]; then
         TARGETS=`dkms status dxgkrnl | grep -E "dxgkrnl/[a-z0-9]+" -o | awk '!a[$0]++'`
-        if [ -z $TARGETS ]; then
+        if [ -z "$TARGETS" ]; then
             echo "Ignored. There is no modules to clean."
             exit 0
         fi

--- a/install.sh
+++ b/install.sh
@@ -75,8 +75,10 @@ install() {
             done
             ;;
         "linux-msft-wsl-6.6.y")
-            PATCHES="linux-msft-wsl-5.15.y/0001-Add-a-gpu-pv-support.patch \
-                    linux-msft-wsl-6.6.y/0002-Fix-eventfd_signal.patch";
+            PATCHES="linux-msft-wsl-5.15.y/0001-Add-a-gpu-pv-support.patch";
+            if [[ "$TARGET_KERNEL_VERSION" != *"truenas"* ]]; then
+                PATCHES="$PATCHES linux-msft-wsl-6.6.y/0002-Fix-eventfd_signal.patch";
+            fi
 
             for PATCH in $PATCHES; do
                 # Patch source files


### PR DESCRIPTION
Checking the `/etc/*-release` file can determinate the linux distribution of the running system.

However, to check the system distribution, it need to check not only `ID_LIKE` but also `ID`, `NAME` or various parameters.

(Issue #2) /etc/os-release:
```
root@truenas[/mnt/data]# cat /etc/os-release
PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
NAME="Debian GNU/Linux"
VERSION_ID="12"
VERSION="12 (bookworm)"
VERSION_CODENAME=bookworm
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```