### PR TITLE
fix: 5.15.0 kernel incompatibility issue

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -61,8 +61,8 @@ install() {
     case $CURRENT_BRANCH in
         "linux-msft-wsl-5.15.y")
             PATCHES="linux-msft-wsl-5.15.y/0001-Add-a-gpu-pv-support.patch \
-                    linux-msft-wsl-5.15.y/0002-Add-a-multiple-kernel-version-support.patch \
-                    linux-msft-wsl-5.15.y/0003-Fix-gpadl-has-incomplete-type-error.patch";
+                    linux-msft-wsl-5.15.y/0002-Add-a-multiple-kernel-version-support.patch";
+                    #linux-msft-wsl-5.15.y/0003-Fix-gpadl-has-incomplete-type-error.patch";
 
             for PATCH in $PATCHES; do
                 # Patch source files


### PR DESCRIPTION
#4

As a result, [0003-Fix-gpadl-has-incomplete-type-error](https://github.com/staralt/dxgkrnl-dkms/blob/main/linux-msft-wsl-5.15.y/0003-Fix-gpadl-has-incomplete-type-error.patch) was not needed in all kernels above 5.15.0.
After removing the patch, the build succeeded.
